### PR TITLE
Add travis options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: rust
 sudo: required
 dist: trusty
+rust:
+  - nightly
+cache: cargo
 script:
-  - cargo build --verbose --all
-  - cargo test --verbose --all
+  - cargo test --verbose


### PR DESCRIPTION
For now, I have to use Rust nightly in order to use the benchmarking library.